### PR TITLE
work on cylinder test case (EB)

### DIFF
--- a/exec/cylinder/inputs
+++ b/exec/cylinder/inputs
@@ -1,26 +1,19 @@
 # Stop time for simulation
-amr.max_step = 2
+amr.max_step = 1
 
 #incflo.fixed_dt = 0.01
 incflo.cfl = 0.5
 
-amrex.fpe_trap_invalid = 1
-
 # Number of grid cells in each direction at the coarsest level
 amr.n_cell = 16 16 16
-
-# Maximum allowable size of each subdomain in the problem domain;
-#    this is used to decompose the domain for parallel calculations.
-amr.max_grid_size = 1024
-
-# Maximum tile size within each grid
-fabarray.mfiter_tile_size = 1024 1024 1024
 
 # Maximum level in hierarchy (for now must be 0, i.e., one level in total)
 amr.max_level = 0
 
+# Plot interval
 amr.plot_int   = 1
 
+# Physics
 incflo.mu_g0   = 0.001
 incflo.ro_g0   = 1.0
 incflo.gravity = 0.0 0.0 0.0
@@ -31,13 +24,15 @@ geometry.is_periodic = 0     1     1      # Is periodic in each direction?
 geometry.prob_lo     = 0.    0.    0.       # lo corner of physical domain
 geometry.prob_hi     = 1.    1.    1.     # hi corner of physical domain
 
+# Add cylinder 
 incflo.geometry = "cylinder"
-
 cylinder.internal_flow = false
-
 cylinder.radius = 0.2
 cylinder.height = 1.0
-
 # Choices for direction are {0,1,2}
 cylinder.direction = 2
 cylinder.center    =  0.5 0.5 0.5
+
+# Trap invalids
+amrex.fpe_trap_invalid = 1
+

--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -184,6 +184,16 @@ void incflo_level::incflo_project_velocity(int lev)
 	//  data structures and set_velocity_bcs routine
 	mac_projection->update_internals();
 
+    // TODO: Remove after debugging
+    {
+        // Swap ghost cells and apply BCs to velocity
+        incflo_set_velocity_bcs(lev, 0);
+        incflo_compute_diveu(lev);
+        //amrex::Print() << (*diveu[lev])[0] << std::endl; 
+        std::string plot_file{"divu"};
+		WritePlotFile(plot_file, 0, 0.01, 0.0);
+	}
+
 	bool proj_2 = true;
 	Real dummy_dt = 1.0;
 	incflo_apply_projection(lev, dummy_dt, proj_2);

--- a/src/incflo_level.H
+++ b/src/incflo_level.H
@@ -257,6 +257,9 @@ private:
 	Real incflo_norm0(const Vector<std::unique_ptr<MultiFab>>& mf, int lev, int comp);
 	Real incflo_norm0(MultiFab& mf, int lev, int comp);
 
+   void incflo_average_cc_to_fc ( int lev, const MultiFab& cc,
+                                 Array<std::unique_ptr<MultiFab>,AMREX_SPACEDIM>& fc );
+   
 	Vector<int> istep = {1};
 
 	// Unit vectors in Cartesian space

--- a/src/io/incfloIO.cpp
+++ b/src/io/incfloIO.cpp
@@ -106,10 +106,7 @@ void incflo_level::WriteCheckPointFile(std::string& check_file, int nstep, Real 
 
 	const std::string& checkpointname = amrex::Concatenate(check_file, nstep);
 
-	if(ParallelDescriptor::IOProcessor())
-	{
-		std::cout << "\n\t Writing checkpoint " << checkpointname << std::endl;
-	}
+    amrex::Print() << "\n\t Writing checkpoint " << checkpointname << std::endl;
 
 	const int nlevels = finestLevel() + 1;
 	amrex::PreBuildDirectorHierarchy(checkpointname, level_prefix, nlevels, true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,8 +138,7 @@ int main(int argc, char* argv[])
 	Real end_init = ParallelDescriptor::second() - strt_time;
 	ParallelDescriptor::ReduceRealMax(end_init, ParallelDescriptor::IOProcessorNumber());
 
-	if(ParallelDescriptor::IOProcessor())
-		std::cout << "Time spent in init      " << end_init << std::endl;
+    amrex::Print() << "Time spent in init      " << end_init << std::endl;
 
 	int finish = 0;
 
@@ -185,8 +184,7 @@ int main(int argc, char* argv[])
 				Real end_step = ParallelDescriptor::second() - strt_step;
 				ParallelDescriptor::ReduceRealMax(end_step,
 												  ParallelDescriptor::IOProcessorNumber());
-				if(ParallelDescriptor::IOProcessor())
-					std::cout << "Time per step        " << end_step << std::endl;
+			    amrex::Print() << "Time per step " << end_step << std::endl;
 
 				if(!steady_state)
 				{
@@ -232,11 +230,8 @@ int main(int argc, char* argv[])
 	Real end_time = ParallelDescriptor::second() - strt_time;
 	ParallelDescriptor::ReduceRealMax(end_time, ParallelDescriptor::IOProcessorNumber());
 
-	if(ParallelDescriptor::IOProcessor())
-	{
-		std::cout << "Time spent in main      " << end_time << std::endl;
-		std::cout << "Time spent in main-init " << end_time - end_init << std::endl;
-	}
+    amrex::Print() << "Time spent in main      " << end_time << std::endl;
+    amrex::Print() << "Time spent in main-init " << end_time - end_init << std::endl;
 
 	BL_PROFILE_REGION_STOP("incflo::main()");
 	BL_PROFILE_VAR_STOP(pmain);


### PR DESCRIPTION
Problem comes from boundary conditions near cylinder, causing z-variation in diveu before the initial project. This acts as a source term for the projection and leads to nonzero dp/dz. 

However, a hack which copies diveu from interior of domain along z near the boundaries (i.e. removes z-variation) does not fix it. It seems the BCs don't work for the pressure gradients either in the same region... 

Need to figure out the correct way of applying divu and pressure BCs in the presence of the cylinder .