### PR TITLE
moved makeFineMask outside of AllocateArrays

### DIFF
--- a/src/incflo.H
+++ b/src/incflo.H
@@ -273,6 +273,7 @@ private:
 	void SetBackgroundPressure();
 	void InitialProjection();
     void InitialIterations();
+    void setup_level_mask();
 
     // Member variables for initial conditions
     int probtype = 0;

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -203,6 +203,12 @@ void incflo::Evolve()
                     regrid(lev, time);
                     incflo_setup_solvers();
                 }
+         
+            }
+         
+            if (nstep % regrid_int == 0)
+            {
+              setup_level_mask();
             }
          
         }*/

--- a/src/setup/incflo_arrays.cpp
+++ b/src/setup/incflo_arrays.cpp
@@ -8,12 +8,9 @@ void incflo::AllocateArrays(int lev)
     // Cell-based arrays
     // ********************************************************************************
 
-    if(lev < finest_level){
-        level_mask[lev].reset(new iMultiFab(makeFineMask(grids[lev],dmap[lev], grids[lev+1], IntVect(2), 1, 0)));
-    } else {
-        level_mask[lev].reset(new iMultiFab(grids[lev], dmap[lev], 1, 0, MFInfo() /*, default factory*/));
-        level_mask[lev]->setVal(1);
-    }
+    // Level Mask = 1 if not covered by a finer patch, else 0
+    level_mask[lev].reset(new iMultiFab(grids[lev], dmap[lev], 1, 0, MFInfo() /*, default factory*/));
+    level_mask[lev]->setVal(1);
     
     // Current Density
     density[lev].reset(new MultiFab(grids[lev], dmap[lev], 1, nghost, MFInfo(), *ebfactory[lev]));
@@ -179,12 +176,9 @@ void incflo::RegridArrays(int lev)
     // FillBoundary().
     //
 
-    if(lev < finest_level){
-        level_mask[lev].reset(new iMultiFab(makeFineMask(grids[lev],dmap[lev], grids[lev+1], IntVect(2), 1, 0)));
-    } else {
-        level_mask[lev].reset(new iMultiFab(grids[lev], dmap[lev], 1, 0, MFInfo() /*, default factory*/));
-        level_mask[lev]->setVal(1);
-    }
+    // Level Mask = 1 if not covered by a finer patch, else 0
+    level_mask[lev].reset(new iMultiFab(grids[lev], dmap[lev], 1, 0, MFInfo() /*, default factory*/));
+    level_mask[lev]->setVal(1);
     
    // Density
    std::unique_ptr<MultiFab> density_new(new MultiFab(grids[lev], dmap[lev], 1, nghost, 

--- a/src/setup/init.cpp
+++ b/src/setup/init.cpp
@@ -260,6 +260,8 @@ void incflo::PostInit(int restart_flag)
     incflo_set_tracer_bcs (cur_time, tracer_o);
     incflo_set_velocity_bcs(cur_time, vel, 0);
 
+    setup_level_mask();
+    
     // Project the initial velocity field to make it divergence free
     // Perform initial iterations to find pressure distribution
     if(!restart_flag)
@@ -268,6 +270,15 @@ void incflo::PostInit(int restart_flag)
             InitialProjection();
         if (initial_iterations > 0)
             InitialIterations();
+    }
+}
+
+void incflo::setup_level_mask(){
+
+     BL_PROFILE("incflo::setup_level_mask");
+
+     for(int lev=0;lev<finest_level;++lev) {
+        *level_mask[lev] = makeFineMask(grids[lev],dmap[lev], grids[lev+1], IntVect(2), 1, 0);
     }
 }
 


### PR DESCRIPTION
moved the level_mask outside of AllocateArrays function because when that function is called the finer level has not been set up yet.

Sorry didn't catch this until running multiple levels. 