### PR TITLE
Replace 'html_context' with 'html_css_files' command

### DIFF
--- a/Docs/sphinx_documentation/source/conf.py
+++ b/Docs/sphinx_documentation/source/conf.py
@@ -129,11 +129,7 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # overrides for wide tables in RTD theme
-        ],
-    }
+html_css_files = ['theme_overrides.css']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
Seems like a dependency update broke the Sphinx Doc styling. To fix it, in `conf.py` I changed the `html_context` command to `html_css_files = [ 'theme_overrides.css' ]`. 