### PR TITLE
Disable Scheduled GitHub Actions on Forks

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   cuda_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/incflo' || github.event_name != 'schedule' }}
     name: CUDA EB 3D
     runs-on: ubuntu-20.04
     env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
@@ -78,6 +79,7 @@ jobs:
         du -hs ~/.cache/ccache
 
   cuda_no_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/incflo' || github.event_name != 'schedule' }}
     name: CUDA NO EB 2D
     runs-on: ubuntu-20.04
     env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   gcc_eb_3d_super:
+    if: ${{ github.repository == 'AMReX-Codes/incflo' || github.event_name != 'schedule' }}
     name: GCC EB 3D
     runs-on: ubuntu-latest
     env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
@@ -82,6 +83,7 @@ jobs:
         mpiexec -n 2 build/incflo.ex test_3d/benchmark.uniform_velocity_sphere incflo.verbose=1 mac_proj.verbose=1 nodal_proj.verbose=1
 
   gcc_no_eb_3d_lib:
+    if: ${{ github.repository == 'AMReX-Codes/incflo' || github.event_name != 'schedule' }}
     name: GCC NO EB 3D
     runs-on: ubuntu-latest
     env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
@@ -166,6 +168,7 @@ jobs:
         mpiexec -n 2 build/incflo.ex test_no_eb_3d/benchmark.rayleigh_taylor max_step=3 incflo.verbose=1 mac_proj.verbose=1 nodal_proj.verbose=1
 
   gcc_eb_2d_lib:
+    if: ${{ github.repository == 'AMReX-Codes/incflo' || github.event_name != 'schedule' }}
     name: GCC EB 2D
     runs-on: ubuntu-latest
     env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
@@ -250,6 +253,7 @@ jobs:
         build/incflo.ex test_2d/benchmark.eb_flow_sphere incflo.verbose=1 mac_proj.verbose=1 nodal_proj.verbose=1
 
   gcc_no_eb_2d_super:
+    if: ${{ github.repository == 'AMReX-Codes/incflo' || github.event_name != 'schedule' }}
     name: GCC NO EB 2D
     runs-on: ubuntu-latest
     env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   hip_no_eb_3d:
+    if: ${{ github.repository == 'AMReX-Codes/incflo' || github.event_name != 'schedule' }}
     name: HIP NO EB 3D
     runs-on: ubuntu-20.04
     env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   sycl_eb_2d:
+    if: ${{ github.repository == 'AMReX-Codes/incflo' || github.event_name != 'schedule' }}
     name: SYCL EB 2D
     runs-on: ubuntu-latest
     env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare -Wno-missing-braces"}


### PR DESCRIPTION
The default branch on a fork is often out of sync with the main repo, resulting in failures in scheduled actions. This disables scheduled actions on forks. Note that `push` and `pull_request` still trigger GitHub actions on forks. If one wants to disable it entirely in their fork, follow the instruction in the link below.

https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow?tool=webui#disabling-a-workflow