### PR TITLE
ensure initial_shrink still gets applied. together with pr83, this

### DIFF
--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -10,7 +10,7 @@ void incflo::Advance()
     Real strt_step = static_cast<Real>(ParallelDescriptor::second());
 
     // Compute time step size
-    int initialisation = 0;
+    int initialisation = ( m_dt < 0 );
     bool explicit_diffusion = (m_diff_type == DiffusionType::Explicit);
     ComputeDt(initialisation, explicit_diffusion);
 


### PR DESCRIPTION
ensures the initial timestep is computed as expected. This will require redoing some regression tests due to the change in the initial dt.