### PR TITLE
Fix for non-conservative tracers

### DIFF
--- a/Docs/sphinx_documentation/source/FluidEquations.rst
+++ b/Docs/sphinx_documentation/source/FluidEquations.rst
@@ -35,9 +35,13 @@ Incompressibility constraint:
 
 .. math:: \nabla \cdot U = 0
 
-Tracer(s):
+Tracer(s): for conservative,
 
 .. math:: \frac{\partial \rho s}{\partial t} + \nabla \cdot (\rho U s)  =  \nabla \cdot \mu_s \nabla s + \rho H_s
 
+or, for non-conservative,
+
+.. math:: \frac{\partial s}{\partial t} + U \cdot \nabla s  =  \nabla \cdot \mu_s \nabla s + H_s
+
 By default, :math:`H_s = 0` and :math:`{\bf H}_U = {\bf 0}`.
-If gravity is set during runtime, then :math:`{\bf H}_U` defaults to :math:`\rho {\bf g}`
+If gravity is set during runtime, then :math:`{\bf H}_U` defaults to :math:`\rho {\bf g}`.

--- a/Docs/sphinx_documentation/source/InputsAlgorithm.rst
+++ b/Docs/sphinx_documentation/source/InputsAlgorithm.rst
@@ -14,6 +14,8 @@ The following inputs must be preceded by "incflo."
 +----------------------+-----------------------------------------------------------------------+-------------+--------------+
 |  advect_tracer       |  evolve the tracer equation(s)?                                       |  bool       |  false       |
 +----------------------+-----------------------------------------------------------------------+-------------+--------------+
+|  trac_is_conservative|  Is tracer conserved? If specified, one entry required per tracer     |  int        |  1           |
++----------------------+-----------------------------------------------------------------------+-------------+--------------+
 |  ntrac               |  number of tracers                                                    |  int        |  1           |
 +----------------------+-----------------------------------------------------------------------+-------------+--------------+
 |  constant_density    |  Only evolve the continuity equation if false                         |  bool       |  true        |

--- a/Docs/sphinx_documentation/source/index.rst
+++ b/Docs/sphinx_documentation/source/index.rst
@@ -8,7 +8,7 @@ the variable density incompressible Navier-Stokes equations in the presence
 of complex geometries.  It includes adaptive mesh refinement (AMR)
 but without subcycling in time.
 
-For an AMReX-based incompressible flow code with subcycling in time, please see `IAMR <https://amrex-fluids.github.io/IAMR/>`_
+For an AMReX-based incompressible flow code with subcycling in time, please see :ref:`IAMR <iamr:iamr_doc_indx>`.
 
 Active development in incflo is ongoing in the development branch.
 


### PR DESCRIPTION
Add updates for non-conserv diffusion that were mistakenly not committed in pr 94.
Also update docs to include non-conservative scalar option.