### PR TITLE
BCType::foextrap as default for (density, BC::slip_wall) combination when advection_type == "BDS"

### DIFF
--- a/src/boundary_conditions/README.org
+++ b/src/boundary_conditions/README.org
@@ -6,7 +6,7 @@
 | v_t    | foextrap | foextrap | ext_dir  | ext_dir (0) | hoextrap                              |
 | rho    | foextrap | foextrap | ext_dir  | foextrap    | if (advection_type == "BDS") foextrap |
 |        |          |          |          |             | else hoextrap                         |
-| scalar | foextrap | foextrap | ext_dir  | foextrap    | foextrap                              |
+| scalar | foextrap | foextrap | ext_dir  | foextrap    | hoextrap                              |
 | force  | foextrap | foextrap | foextrap | foextrap    | foextrap                              |
 
 * projection

--- a/src/boundary_conditions/README.org
+++ b/src/boundary_conditions/README.org
@@ -6,7 +6,8 @@
 | v_t    | foextrap | foextrap | ext_dir  | ext_dir (0) | hoextrap                              |
 | rho    | foextrap | foextrap | ext_dir  | foextrap    | if (advection_type == "BDS") foextrap |
 |        |          |          |          |             | else hoextrap                         |
-| scalar | foextrap | foextrap | ext_dir  | foextrap    | hoextrap                              |
+| scalar | foextrap | foextrap | ext_dir  | foextrap    | if (advection_type == "BDS") foextrap |
+|        |          |          |          |             | else hoextrap                         |
 | force  | foextrap | foextrap | foextrap | foextrap    | foextrap                              |
 
 * projection

--- a/src/boundary_conditions/README.org
+++ b/src/boundary_conditions/README.org
@@ -1,12 +1,13 @@
 * fillpatch
 
-|        | pi       | po       | mi       | nsw         | sw          |
-|--------+----------+----------+----------+-------------+-------------|
-| v_n    | foextrap | foextrap | ext_dir  | ext_dir (0) | ext_dir (0) |
-| v_t    | foextrap | foextrap | ext_dir  | ext_dir (0) | hoextrap    |
-| rho    | foextrap | foextrap | ext_dir  | foextrap    | foextrap    |
-| scalar | foextrap | foextrap | ext_dir  | foextrap    | foextrap    |
-| force  | foextrap | foextrap | foextrap | foextrap    | foextrap    |
+|        | pi       | po       | mi       | nsw         | sw                                    |
+|--------+----------+----------+----------+-------------+---------------------------------------|
+| v_n    | foextrap | foextrap | ext_dir  | ext_dir (0) | ext_dir (0)                           |
+| v_t    | foextrap | foextrap | ext_dir  | ext_dir (0) | hoextrap                              |
+| rho    | foextrap | foextrap | ext_dir  | foextrap    | if (advection_type == "BDS") foextrap |
+|        |          |          |          |             | else hoextrap                         |
+| scalar | foextrap | foextrap | ext_dir  | foextrap    | foextrap                              |
+| force  | foextrap | foextrap | foextrap | foextrap    | foextrap                              |
 
 * projection
 

--- a/src/boundary_conditions/boundary_conditions.cpp
+++ b/src/boundary_conditions/boundary_conditions.cpp
@@ -267,12 +267,14 @@ void incflo::init_bcs ()
             else if (bct == BC::slip_wall)
             {
                 if (side == Orientation::low) {
+                    // BDS requires foextrap to avoid introduction of local max/min
                     if (m_advection_type == "BDS") {
                         m_bcrec_density[0].setLo(dir, BCType::foextrap);
                     } else{
                         m_bcrec_density[0].setLo(dir, BCType::hoextrap);
                     }
                 } else {
+                    // BDS requires foextrap to avoid introduction of local max/min
                     if (m_advection_type == "BDS") {
                         m_bcrec_density[0].setHi(dir, BCType::foextrap);
                     } else {
@@ -335,9 +337,25 @@ void incflo::init_bcs ()
             else if (bct == BC::slip_wall)
             {
                 if (side == Orientation::low) {
-                    for (auto& b : m_bcrec_tracer) b.setLo(dir, BCType::hoextrap);
+                    for (auto& b : m_bcrec_tracer) {
+                        // BDS requires foextrap to avoid introduction
+                        // of local max/min
+                        if (m_advection_type == "BDS") {
+                            b.setLo(dir, BCType::foextrap);
+                        } else {
+                            b.setLo(dir, BCType::hoextrap);
+                        }
+                    }
                 } else {
-                    for (auto& b : m_bcrec_tracer) b.setHi(dir, BCType::hoextrap);
+                    for (auto& b : m_bcrec_tracer) {
+                        // BDS requires foextrap to avoid introduction
+                        // of local max/min
+                        if (m_advection_type == "BDS") {
+                            b.setHi(dir, BCType::foextrap);
+                        } else {
+                            b.setHi(dir, BCType::hoextrap);
+                        }
+                    }
                 }
             }
             else if (bct == BC::mass_inflow)

--- a/src/boundary_conditions/boundary_conditions.cpp
+++ b/src/boundary_conditions/boundary_conditions.cpp
@@ -267,9 +267,17 @@ void incflo::init_bcs ()
             else if (bct == BC::slip_wall)
             {
                 if (side == Orientation::low) {
-                    m_bcrec_density[0].setLo(dir, BCType::hoextrap);
+                    if (m_advection_type == "BDS") {
+                        m_bcrec_density[0].setLo(dir, BCType::foextrap);
+                    } else{
+                        m_bcrec_density[0].setLo(dir, BCType::hoextrap);
+                    }
                 } else {
-                    m_bcrec_density[0].setHi(dir, BCType::hoextrap);
+                    if (m_advection_type == "BDS") {
+                        m_bcrec_density[0].setHi(dir, BCType::foextrap);
+                    } else {
+                        m_bcrec_density[0].setHi(dir, BCType::hoextrap);
+                    }
                 }
             }
             else if (bct == BC::mass_inflow)


### PR DESCRIPTION
Making `BCType::foextrap` as the default type for _density_ and _tracer_ at `BC::slip_wall` boundary only when `advection_type == "BDS"`. Also made a minor change in docs (`src/boundary_conditions/README.org`) for _(scalar/density, sw)_ combination.   