### PR TITLE
Define one p and fix BC for cc_proj

### DIFF
--- a/src/projection/incflo_projection_bc.cpp
+++ b/src/projection/incflo_projection_bc.cpp
@@ -23,7 +23,11 @@ incflo::get_projection_bc (Orientation::Side side) const noexcept
             case BC::direction_dependent:
             case BC::mixed:
             {
-                r[dir] = LinOpBCType::inflow;
+                if ( m_use_cc_proj ) {
+                    r[dir] = LinOpBCType::Neumann;
+                } else {
+                    r[dir] = LinOpBCType::inflow;
+                }
                 break;
             }
             case BC::slip_wall:

--- a/src/setup/incflo_arrays.cpp
+++ b/src/setup/incflo_arrays.cpp
@@ -20,15 +20,17 @@ incflo::LevelData::LevelData (amrex::BoxArray const& ba,
       tracer_o  (ba, dm, my_incflo->m_ntrac, my_incflo->nghost_state(), MFInfo(), fact),
 
       mac_phi   (ba, dm, 1             , 1       , MFInfo(), fact),
-      p_cc      (ba, dm, 1             , 1       , MFInfo(), fact),
-      p_nd      (amrex::convert(ba,IntVect::TheNodeVector()),
-                 dm, 1             , 0 , MFInfo(), fact),
       gp        (ba, dm, AMREX_SPACEDIM, 0 , MFInfo(), fact),
 
       conv_velocity_o (ba, dm, AMREX_SPACEDIM    , 0, MFInfo(), fact),
       conv_density_o  (ba, dm, 1                 , 0, MFInfo(), fact),
       conv_tracer_o   (ba, dm, my_incflo->m_ntrac, 0, MFInfo(), fact)
 {
+    if (my_incflo->m_use_cc_proj) {
+        p_cc.define(ba                                  , dm, 1, 1, MFInfo(), fact);
+    } else {
+        p_nd.define(convert(ba,IntVect::TheNodeVector()), dm, 1, 0, MFInfo(), fact);
+    }
     if (my_incflo->m_advection_type != "MOL") {
         divtau_o.define(ba, dm, AMREX_SPACEDIM, 0, MFInfo(), fact);
         if (my_incflo->m_advect_tracer) {

--- a/src/utilities/io.cpp
+++ b/src/utilities/io.cpp
@@ -98,10 +98,10 @@ void incflo::WriteCheckPointFile() const
 
         if (m_use_cc_proj) {
             VisMF::Write(m_leveldata[lev]->p_cc,
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "p_nd"));
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "p_cc"));
         } else {
             VisMF::Write(m_leveldata[lev]->p_nd,
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "p_cc"));
+                         amrex::MultiFabFileFullPrefix(lev, checkpointname, level_prefix, "p_nd"));
         }
     }
 
@@ -232,11 +232,11 @@ void incflo::ReadCheckpointFile()
                     amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "gradp"));
 
         if (m_use_cc_proj) {
-            VisMF::Read(m_leveldata[lev]->p_nd,
-                        amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "p_nd"));
-        } else {
             VisMF::Read(m_leveldata[lev]->p_cc,
                         amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "p_cc"));
+        } else {
+            VisMF::Read(m_leveldata[lev]->p_nd,
+                        amrex::MultiFabFileFullPrefix(lev, m_restart_file, level_prefix, "p_nd"));
         }
     }
 


### PR DESCRIPTION
This PR contains
* Now only define one pressure MultiFab, p_cc if m_use_cc_proj and p_nd otherwise
* For use_cc_proj, use LinOpBCType::Neumann in place of LinOpBCType::inflow (which is for nodal_proj only)
* In checkpoint file write, fix MultiFabFileFullPrefix name parameter
* In checkpoint file read, if use_cc_proj use p_cc, otherwise use p_nd