### PR TITLE
Ebflow tracer diffusion bc

### DIFF
--- a/src/diffusion/DiffusionScalarOp.cpp
+++ b/src/diffusion/DiffusionScalarOp.cpp
@@ -231,6 +231,12 @@ DiffusionScalarOp::diffuse_scalar (Vector<MultiFab*> const& tracer,
                     }
                 }
 
+                if (m_incflo->hasEBFlow()) {
+                    MultiFab phi(*m_incflo->get_tracer_eb()[lev], amrex::make_alias, comp, 1);
+                  m_eb_scal_solve_op->setEBDirichlet(lev, phi, *eta[lev]);
+                } // else use default homogeneous Neumann on EB
+
+
                 Array<MultiFab,AMREX_SPACEDIM> b = m_incflo->average_scalar_eta_to_faces(lev, comp, *eta[lev]);
                 m_eb_scal_solve_op->setBCoeffs(lev, GetArrOfConstPtrs(b), MLMG::Location::FaceCentroid);
             }

--- a/src/setup/incflo_arrays.cpp
+++ b/src/setup/incflo_arrays.cpp
@@ -8,15 +8,12 @@ incflo::LevelData::LevelData (amrex::BoxArray const& ba,
                               incflo* my_incflo)
     : velocity    (ba, dm, AMREX_SPACEDIM, my_incflo->nghost_state(), MFInfo(), fact),
       velocity_o  (ba, dm, AMREX_SPACEDIM, my_incflo->nghost_state(), MFInfo(), fact),
-      velocity_eb (ba, dm, AMREX_SPACEDIM, my_incflo->nghost_state(), MFInfo(), fact),
 
       density     (ba, dm, 1             , my_incflo->nghost_state(), MFInfo(), fact),
-      density_eb  (ba, dm, 1             , my_incflo->nghost_state(), MFInfo(), fact),
       density_o   (ba, dm, 1             , my_incflo->nghost_state(), MFInfo(), fact),
       density_nph (ba, dm, 1             , my_incflo->nghost_state(), MFInfo(), fact),
 
       tracer    (ba, dm, my_incflo->m_ntrac, my_incflo->nghost_state(), MFInfo(), fact),
-      tracer_eb (ba, dm, my_incflo->m_ntrac, my_incflo->nghost_state(), MFInfo(), fact),
       tracer_o  (ba, dm, my_incflo->m_ntrac, my_incflo->nghost_state(), MFInfo(), fact),
 
       mac_phi   (ba, dm, 1             , 1       , MFInfo(), fact),
@@ -31,6 +28,13 @@ incflo::LevelData::LevelData (amrex::BoxArray const& ba,
     } else {
         p_nd.define(convert(ba,IntVect::TheNodeVector()), dm, 1, 0, MFInfo(), fact);
     }
+#ifdef AMREX_USE_EB
+    if (my_incflo->hasEBFlow()) {
+        velocity_eb.define(ba, dm, AMREX_SPACEDIM, my_incflo->nghost_state(), MFInfo(), fact);
+        density_eb.define (ba, dm, 1             , my_incflo->nghost_state(), MFInfo(), fact);
+        tracer_eb.define  (ba, dm, my_incflo->m_ntrac, my_incflo->nghost_state(), MFInfo(), fact);
+    }
+#endif
     if (my_incflo->m_advection_type != "MOL") {
         divtau_o.define(ba, dm, AMREX_SPACEDIM, 0, MFInfo(), fact);
         if (my_incflo->m_advect_tracer) {

--- a/test_2d/benchmark.eb_flow_const_vely
+++ b/test_2d/benchmark.eb_flow_const_vely
@@ -28,6 +28,9 @@ incflo.fluid_model      =   "newtonian" # Fluid model (rheology)
 incflo.mu               =   0.001       # Dynamic viscosity coefficient
 incflo.constant_density =   true        #
 
+incflo.advect_tracer = true
+incflo.mu_s = 0.1
+
 incflo.advection_type        =  "Godunov" 
 incflo.redistribution_type   =  "StateRedist" 
 
@@ -81,3 +84,4 @@ nodal_proj.verbose        =   1         # Nodal Projector
 #               EB FLOW                 #
 #.......................................#
 eb_flow.vel_mag        =  0.1
+eb_flow.tracer         =  1.


### PR DESCRIPTION
This PR includes three changes
* If using tracer(s) and flow through the EB, the tracer diffusion solve now uses a Dirichlet BC for the EB.
* Only define the MFs that hold EB Dirichlet values if they're needed
* Updates benchmark.eb_flow_const_vely to evolve a tracer
This will require updating the eb_flowy_2d regression test bencchmark