### PR TITLE
Fix for a minor typo in implicit temperature update.

### DIFF
--- a/src/incflo_update_temperature.cpp
+++ b/src/incflo_update_temperature.cpp
@@ -83,7 +83,7 @@ void incflo::update_temperature (StepType step_type, Vector<MultiFab>& tem_eta, 
                     ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                     {
                         tem(i,j,k) = tem_o(i,j,k) + l_dt *
-                            (dtdt_o(i,j,k) + tem_f(i,j,k)) / (rho_h(i,j,k) * cp(i,j,k));
+                            (dtdt_o(i,j,k) + tem_f(i,j,k) / (rho_h(i,j,k) * cp(i,j,k)));
                         // Save rhoCp for use in implicit solve.
                         // Reuse scratch space since we are done with forcing now.
                         tem_f(i,j,k) = rho_h(i,j,k) * cp(i,j,k);


### PR DESCRIPTION
There was a minor typo in `incflo_update_temperature.cpp` when implicit diffusion is used. 