### PR TITLE
Fix index typo in z-lo direction_dependent MAC velocity BC.

### DIFF
--- a/src/convection/incflo_compute_MAC_projected_velocities.cpp
+++ b/src/convection/incflo_compute_MAC_projected_velocities.cpp
@@ -251,7 +251,7 @@ incflo::compute_MAC_projected_velocities (
                 int n = 2;
                 const auto bc = HydroBC::getBC(i, j, k, n, domain, bc_vel_d, velbc_arr);
                 if (k == dlo.z && ( bc.lo(2) == BCType::ext_dir ||
-                                   (bc.lo(2) == BCType::direction_dependent && cc_arr(1,j,k-1,2) >= Real(0.0)) ) ) {
+                                   (bc.lo(2) == BCType::direction_dependent && cc_arr(i,j,k-1,2) >= Real(0.0)) ) ) {
                     wmac_arr(i,j,k) = cc_arr(i,j,k-1,2);
                 }
                 if (k == dhi.z && ( bc.hi(2) == BCType::ext_dir ||


### PR DESCRIPTION
The inflow test read cc_arr(1,j,k-1,2) with a literal x-index 1 instead of the loop index i, so the decision for face (i,j,dlo.z) was made from the ghost w in the x=1 column, and the read went outside the FAB on any box whose grown x-range excludes 1.  Use cc_arr(i,j,k-1,2), the same ghost cell that is assigned to wmac_arr(i,j,k), matching the x-lo, y-lo and z-hi blocks.

Fixes #195.