### PR TITLE
Fix inverted guard in fillcoarsepatch_temperature.

### DIFF
--- a/src/boundary_conditions/incflo_fillpatch.cpp
+++ b/src/boundary_conditions/incflo_fillpatch.cpp
@@ -273,7 +273,7 @@ void incflo::fillcoarsepatch_tracer (int lev, Real time, MultiFab& tracer, int n
 
 void incflo::fillcoarsepatch_temperature (int lev, Real time, MultiFab& temperature, int ng)
 {
-    if (m_use_temperature) return;
+    if (!m_use_temperature) return;
 
     const auto& bcrec = get_temperature_bcrec();
     PhysBCFunct<GpuBndryFuncFab<IncfloTempFill> > cphysbc


### PR DESCRIPTION
The early return fired when m_use_temperature was true, so a new AMR level's temperature was never filled from the coarse level.

Fixes #192.