### PR TITLE
Guard the cell-volume product by dimension in massDensity.

### DIFF
--- a/src/particles/incflo_PCUtils.cpp
+++ b/src/particles/incflo_PCUtils.cpp
@@ -18,7 +18,7 @@ void incflo_PC::massDensity ( MultiFab&  a_mf,
     const auto plo = geom.ProbLoArray();
     const auto dxi = geom.InvCellSizeArray();
 
-    const Real inv_cell_volume = dxi[0]*dxi[1]*dxi[2];
+    const Real inv_cell_volume = AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2]);
     a_mf.setVal(0.0);
 
     ParticleToMesh( *this, a_mf, a_lev,


### PR DESCRIPTION
dxi is a GpuArray with SPACEDIM entries, so dxi[0]*dxi[1]*dxi[2] read past the end in 2D builds. AMREX_D_TERM gives the inverse cell area in 2D and leaves 3D unchanged.

Fixes #168.