### PR TITLE
Fix transposed geometry name in the CSG dispatch.

### DIFF
--- a/src/embedded_boundaries/embedded_boundaries.cpp
+++ b/src/embedded_boundaries/embedded_boundaries.cpp
@@ -81,7 +81,7 @@ void incflo::MakeEBGeometry()
         make_eb_stl();
     }
 #ifdef CSG_EB
-    else if(!csg_file.empty() || geom_type == "cgs") {
+    else if(!csg_file.empty() || geom_type == "csg") {
         amrex::Print() << "\n Building geometry from .csg file:  " << csg_file << "\n";
         make_eb_csg(csg_file);
     }


### PR DESCRIPTION
MakeEBGeometry tested geom_type == "cgs", so incflo.geometry = csg fell through to the final else and silently built all-regular geometry. Every other part of the CSG path spells it "csg".

Fixes #172.