### PR TITLE
Accumulate the correct cumulative ref_ratio in ErrorEst.

### DIFF
--- a/src/incflo_tagging.cpp
+++ b/src/incflo_tagging.cpp
@@ -170,7 +170,7 @@ void incflo::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
                 MultiFab::Copy(*mf, temp_dat, 0, 0, 1, 0);
             } else {
                 for (int d = 0; d < AMREX_SPACEDIM; d++) {
-                    rr[d] *= ref_ratio[levc][d];
+                    rr[d] *= ref_ratio[lev-1][d];
                 }
                 average_down(temp_dat, temp_dat_crse, 0, 1, rr);
                 MultiFab::Add(*mf, temp_dat_crse, 0, 0, 1, 0);


### PR DESCRIPTION
The particle-count loop multiplied rr by ref_ratio[levc] every iteration, giving ref_ratio[levc]^(lev-levc) rather than the product over levc..lev-1, so average_down used the wrong ratio when per-level ratios differ. Unchanged for uniform amr.ref_ratio.

Fixes #173.