### PR TITLE
Guard particle name list accesses against an empty list.

### DIFF
--- a/src/incflo_tagging.cpp
+++ b/src/incflo_tagging.cpp
@@ -145,7 +145,7 @@ void incflo::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
 #endif
 
 #ifdef INCFLO_USE_PARTICLES
-    if (m_refine_particles)
+    if (m_refine_particles && !particleData.getNames().empty())
     {
         //
         // This allows dynamic refinement based on the number of particles per cell

--- a/src/utilities/io.cpp
+++ b/src/utilities/io.cpp
@@ -677,7 +677,9 @@ void incflo::WritePlotVariables(Vector<std::string> vars, const std::string& plo
             for (int lev = 0; lev <= finest_level; ++lev) {
                 MultiFab temp_dat(mf[lev].boxArray(), mf[lev].DistributionMap(), 1, 0);
                 temp_dat.setVal(0);
-                particleData[particles_namelist[0]]->Increment(temp_dat, lev);
+                if (!particles_namelist.empty()) {
+                    particleData[particles_namelist[0]]->Increment(temp_dat, lev);
+                }
                 MultiFab::Copy(mf[lev], temp_dat, 0, icomp, 1, 0);
             }
             pltscaVarsName.push_back("particle_count");


### PR DESCRIPTION
ErrorEst and the particle_count plot variable both indexed element 0 of particleData.getNames(), which is empty unless use_tracer_particles is set, and operator[] returns nullptr on a miss. m_refine_particles and plt_ccse_regtest reach both sites by default.

Fixes #174.